### PR TITLE
Generate DB queries from schema and table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master / unreleased
 
 * [FEATURE] Allow storing and reloading configuration from PostgreSQL via JSON endpoints
+* [CHANGE] Remove `config.db_query` and `config.db_upsert` flags; SQL statements are built from schema and table settings
 
 ## 0.27.0 / 2025-06-26
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ retry_interval: 1m
 EOF
 ```
 
+The SQL queries to load or store the configuration are derived from the
+`schema` and `table` values above. Manual overrides via flags are no longer
+supported.
+
 Import an existing `blackbox.yml` into the database:
 
 ```bash

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -158,6 +158,36 @@ func TestHideConfigSecrets(t *testing.T) {
 	}
 }
 
+func TestBuildQueries(t *testing.T) {
+	cases := []struct {
+		schema  string
+		table   string
+		selectQ string
+		upsertQ string
+	}{
+		{
+			table:   "cfg",
+			selectQ: "SELECT config FROM \"cfg\" WHERE id = $1",
+			upsertQ: "INSERT INTO \"cfg\" (id, config) VALUES ($1, $2::jsonb) ON CONFLICT (id) DO UPDATE SET config = EXCLUDED.config",
+		},
+		{
+			schema:  "public",
+			table:   "cfg",
+			selectQ: "SELECT config FROM \"public\".\"cfg\" WHERE id = $1",
+			upsertQ: "INSERT INTO \"public\".\"cfg\" (id, config) VALUES ($1, $2::jsonb) ON CONFLICT (id) DO UPDATE SET config = EXCLUDED.config",
+		},
+	}
+	for _, c := range cases {
+		s, u := buildQueries(c.schema, c.table)
+		if s != c.selectQ {
+			t.Errorf("unexpected select query %q, want %q", s, c.selectQ)
+		}
+		if u != c.upsertQ {
+			t.Errorf("unexpected upsert query %q, want %q", u, c.upsertQ)
+		}
+	}
+}
+
 func TestIsEncodingAcceptable(t *testing.T) {
 	testcases := map[string]struct {
 		input          string


### PR DESCRIPTION
## Summary
- remove configurable SQL flags and build DB queries from schema and table settings
- document automatic SQL generation in README and CHANGELOG
- test helper to verify query construction

## Testing
- `go test ./...` *(fails: http TLS handshake error in prober tests)*

------
https://chatgpt.com/codex/tasks/task_e_6892f9ce62348332904a3abc8679b023